### PR TITLE
switch pathlib2 and pathlib import order

### DIFF
--- a/modape/modis/collect.py
+++ b/modape/modis/collect.py
@@ -10,9 +10,9 @@ from __future__ import absolute_import, division, print_function
 import gc
 import os
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import re
 import time
 import traceback

--- a/modape/modis/download.py
+++ b/modape/modis/download.py
@@ -12,9 +12,9 @@ from datetime import datetime
 import os
 from os.path import basename
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import re
 from subprocess import Popen
 import sys

--- a/modape/modis/smooth.py
+++ b/modape/modis/smooth.py
@@ -13,9 +13,9 @@ import multiprocessing as mp
 import os
 from os.path import basename
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import time
 
 import numpy as np

--- a/modape/modis/window.py
+++ b/modape/modis/window.py
@@ -11,9 +11,9 @@ from contextlib import contextmanager
 from datetime import datetime
 from os.path import basename
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import re
 
 

--- a/modape/scripts/csv_smooth.py
+++ b/modape/scripts/csv_smooth.py
@@ -6,9 +6,9 @@ from __future__ import absolute_import, division, print_function
 import argparse
 from array import array
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import sys
 import time
 

--- a/modape/scripts/modis_collect.py
+++ b/modape/scripts/modis_collect.py
@@ -8,9 +8,9 @@ import argparse
 import multiprocessing as mp
 import os
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import re
 import sys
 import time

--- a/modape/scripts/modis_download.py
+++ b/modape/scripts/modis_download.py
@@ -7,9 +7,9 @@ import argparse
 import datetime
 import os
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import pickle
 import re
 from subprocess import check_output

--- a/modape/scripts/modis_product_table.py
+++ b/modape/scripts/modis_product_table.py
@@ -5,9 +5,9 @@ from __future__ import absolute_import, division, print_function
 
 import argparse
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import pickle
 
 import pandas as pd ## pylint: disable=import-error

--- a/modape/scripts/modis_window.py
+++ b/modape/scripts/modis_window.py
@@ -9,9 +9,9 @@ from __future__ import absolute_import, division, print_function
 import argparse
 import os
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import pickle
 import re
 import sys

--- a/modape/scripts/rts_smooth.py
+++ b/modape/scripts/rts_smooth.py
@@ -7,9 +7,9 @@ from array import array
 import os
 from os.path import basename
 try:
-    from pathlib import Path
-except ImportError:
     from pathlib2 import Path
+except ImportError:
+    from pathlib import Path
 import sys
 import time
 


### PR DESCRIPTION
Switching the import order for pathlib2 and pathlib resolves an issue for py27 users ... even those should rethink their choices.