### PR TITLE
Robust downloading

### DIFF
--- a/modape/data/hdf.xml
+++ b/modape/data/hdf.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE GranuleMetaDataFile SYSTEM "http://ecsinfo.gsfc.nasa.gov/ECSInfo/ecsmetadata/dtds/DPL/ECS/ScienceGranuleMetadata.dtd">
+<GranuleMetaDataFile>
+    <DTDVersion>1.0</DTDVersion>
+    <DataCenterId>EDC</DataCenterId>
+    <GranuleURMetaData>
+        <GranuleUR>SC:MYD11A2.006:2427006926</GranuleUR>
+        <DbID>2427006926</DbID>
+        <InsertTime>2020-12-22 17:24:38.230</InsertTime>
+        <LastUpdate>2020-12-22 17:24:38.230</LastUpdate>
+        <CollectionMetaData>
+            <ShortName>MYD11A2</ShortName>
+            <VersionID>6</VersionID>
+        </CollectionMetaData>
+        <DataFiles>
+            <DataFileContainer>
+                <DistributedFileName>MYD11A2.A2020345.h20v08.006.2020357230859.hdf</DistributedFileName>
+                <FileSize>7526571</FileSize>
+                <ChecksumType>CKSUM</ChecksumType>
+                <Checksum>1534015008</Checksum>
+                <ChecksumOrigin>DPLIngst</ChecksumOrigin>
+            </DataFileContainer>
+        </DataFiles>
+        <ECSDataGranule>
+            <SizeMBECSDataGranule>7.1779</SizeMBECSDataGranule>
+            <ReprocessingPlanned>further update is anticipated</ReprocessingPlanned>
+            <ReprocessingActual>reprocessed</ReprocessingActual>
+            <LocalGranuleID>MYD11A2.A2020345.h20v08.006.2020357230859.hdf</LocalGranuleID>
+            <DayNightFlag>Both</DayNightFlag>
+            <ProductionDateTime>2020-12-22 23:08:59.000</ProductionDateTime>
+            <LocalVersionID>6.3.0</LocalVersionID>
+        </ECSDataGranule>
+        <PGEVersionClass>
+            <PGEVersion>6.3.4</PGEVersion>
+        </PGEVersionClass>
+        <RangeDateTime>
+            <RangeEndingTime>23:59:59.000000</RangeEndingTime>
+            <RangeEndingDate>2020-12-17</RangeEndingDate>
+            <RangeBeginningTime>00:00:00.000000</RangeBeginningTime>
+            <RangeBeginningDate>2020-12-10</RangeBeginningDate>
+        </RangeDateTime>
+        <SpatialDomainContainer>
+            <HorizontalSpatialDomainContainer>
+                <GPolygon>
+                    <Boundary>
+                        <Point>
+                            <PointLongitude>20.3042992912497</PointLongitude>
+                            <PointLatitude>9.99583333333334</PointLatitude>
+                        </Point>
+                        <Point>
+                            <PointLongitude>30.4585481824293</PointLongitude>
+                            <PointLatitude>9.99583333333334</PointLatitude>
+                        </Point>
+                        <Point>
+                            <PointLongitude>29.9958248651597</PointLongitude>
+                            <PointLatitude>0.00416666666666217</PointLatitude>
+                        </Point>
+                        <Point>
+                            <PointLongitude>19.9958412755706</PointLongitude>
+                            <PointLatitude>0.00416666666666217</PointLatitude>
+                        </Point>
+                    </Boundary>
+                </GPolygon>
+            </HorizontalSpatialDomainContainer>
+        </SpatialDomainContainer>
+        <MeasuredParameter>
+            <MeasuredParameterContainer>
+                <ParameterName>MOD 8-DAY 1KM L3 LST</ParameterName>
+                <QAStats>
+                    <QAPercentMissingData>0</QAPercentMissingData>
+                    <QAPercentOutofBoundsData>0</QAPercentOutofBoundsData>
+                    <QAPercentInterpolatedData>0</QAPercentInterpolatedData>
+                    <QAPercentCloudCover>2</QAPercentCloudCover>
+                </QAStats>
+                <QAFlags>
+                    <AutomaticQualityFlag>Passed</AutomaticQualityFlag>
+                    <AutomaticQualityFlagExplanation>No automatic quality assessment is performed in the PGE</AutomaticQualityFlagExplanation>
+                    <OperationalQualityFlag>Passed</OperationalQualityFlag>
+                    <OperationalQualityFlagExplanation>Passed</OperationalQualityFlagExplanation>
+                    <ScienceQualityFlag>Not Investigated</ScienceQualityFlag>
+                    <ScienceQualityFlagExplanation>See http://landweb.nascom/nasa.gov/cgi-bin/QA_WWW/qaFlagPage.cgi?sat=aqua&amp;ver=C6 the product Science Quality status.</ScienceQualityFlagExplanation>
+                </QAFlags>
+            </MeasuredParameterContainer>
+        </MeasuredParameter>
+        <Platform>
+            <PlatformShortName>Aqua</PlatformShortName>
+            <Instrument>
+                <InstrumentShortName>MODIS</InstrumentShortName>
+                <Sensor>
+                    <SensorShortName>MODIS</SensorShortName>
+                </Sensor>
+            </Instrument>
+        </Platform>
+        <PSAs>
+            <PSA>
+                <PSAName>QAPERCENTGOODQUALITY</PSAName>
+                <PSAValue>76</PSAValue>
+            </PSA>
+            <PSA>
+                <PSAName>QAPERCENTOTHERQUALITY</PSAName>
+                <PSAValue>22</PSAValue>
+            </PSA>
+            <PSA>
+                <PSAName>QAPERCENTNOTPRODUCEDCLOUD</PSAName>
+                <PSAValue>02</PSAValue>
+            </PSA>
+            <PSA>
+                <PSAName>QAPERCENTNOTPRODUCEDOTHER</PSAName>
+                <PSAValue>00</PSAValue>
+            </PSA>
+            <PSA>
+                <PSAName>CLOUD_CONTAMINATED_LST_SCREENED</PSAName>
+                <PSAValue>YES</PSAValue>
+            </PSA>
+            <PSA>
+                <PSAName>HORIZONTALTILENUMBER</PSAName>
+                <PSAValue>20</PSAValue>
+            </PSA>
+            <PSA>
+                <PSAName>VERTICALTILENUMBER</PSAName>
+                <PSAValue>08</PSAValue>
+            </PSA>
+            <PSA>
+                <PSAName>TileID</PSAName>
+                <PSAValue>51020008</PSAValue>
+            </PSA>
+            <PSA>
+                <PSAName>identifier_product_doi</PSAName>
+                <PSAValue>10.5067/MODIS/MYD11A2.006</PSAValue>
+            </PSA>
+            <PSA>
+                <PSAName>identifier_product_doi_authority</PSAName>
+                <PSAValue>http://dx.doi.org</PSAValue>
+            </PSA>
+        </PSAs>
+        <InputGranule>
+            <InputPointer>MYD11A1.A2020345.h20v08.006.2020347095253.hdf</InputPointer>
+            <InputPointer>MYD11A1.A2020346.h20v08.006.2020347184904.hdf</InputPointer>
+            <InputPointer>MYD11A1.A2020347.h20v08.006.2020348180329.hdf</InputPointer>
+            <InputPointer>MYD11A1.A2020348.h20v08.006.2020349171355.hdf</InputPointer>
+            <InputPointer>MYD11A1.A2020349.h20v08.006.2020350175939.hdf</InputPointer>
+            <InputPointer>MYD11A1.A2020350.h20v08.006.2020351170326.hdf</InputPointer>
+            <InputPointer>MYD11A1.A2020351.h20v08.006.2020356194912.hdf</InputPointer>
+            <InputPointer>MYD11A1.A2020352.h20v08.006.2020357222919.hdf</InputPointer>
+        </InputGranule>
+        <BrowseProduct>
+            <BrowseGranuleId>UR:10:DsShESDTUR:UR:15:DsShSciServerUR:13:[EDC:DSSDSRV]:24:BR:Browse.001:2427006932</BrowseGranuleId>
+        </BrowseProduct>
+    </GranuleURMetaData>
+</GranuleMetaDataFile>
+
+

--- a/modape/exceptions.py
+++ b/modape/exceptions.py
@@ -1,6 +1,6 @@
 """Custom exceptions for MODAPE"""
 #pylint: disable=W0107
-from typing import List, Tuple
+from typing import List
 
 class DownloadError(Exception):
     """Exception for failed download of MODIS data"""

--- a/modape/exceptions.py
+++ b/modape/exceptions.py
@@ -9,7 +9,7 @@ class DownloadError(Exception):
         """Init custom DownloadError Exception.
 
         Args:
-            fails (List[Tuple]): List of failed file IDs.
+            fails (List): List of failed file IDs.
         """
 
 

--- a/modape/exceptions.py
+++ b/modape/exceptions.py
@@ -5,11 +5,11 @@ from typing import List, Tuple
 class DownloadError(Exception):
     """Exception for failed download of MODIS data"""
 
-    def __init__(self, fails: List[Tuple]) -> None:
+    def __init__(self, fails: List) -> None:
         """Init custom DownloadError Exception.
 
         Args:
-            fails (List[Tuple]): List of failed downloads. Each is tuple with (URI, Error).
+            fails (List[Tuple]): List of failed file IDs.
         """
 
 
@@ -20,8 +20,8 @@ ERROR downloading MODIS data!
 Failed downloads:
 
 """
-        for failed, error in fails:
-            message += f"{failed}: {error}\n"
+        for failed in fails:
+            message += f"{failed}\n"
 
         super(DownloadError, self).__init__(message)
 

--- a/modape/modis/download.py
+++ b/modape/modis/download.py
@@ -221,15 +221,14 @@ class ModisQuery(object):
 
                 with session.get(url, stream=True, allow_redirects=True) as response:
                     response.raise_for_status()
-
                     with open(filename_temp, "wb") as openfile:
                         shutil.copyfileobj(response.raw, openfile, length=16*1024*1024)
 
                 if check:
 
-                    response = session.get(url + ".xml")
-                    response.raise_for_status()
-                    file_metadata = self._parse_hdfxml(response)
+                    with session.get(url + ".xml") as response:
+                        response.raise_for_status()
+                        file_metadata = self._parse_hdfxml(response)
 
                     # check filesize
                     assert filename_temp.stat().st_size == file_metadata["FileSize"]

--- a/modape/modis/download.py
+++ b/modape/modis/download.py
@@ -242,6 +242,10 @@ class ModisQuery(object):
                 shutil.move(filename_temp, filename)
 
             except (HTTPError, AssertionError, FileNotFoundError) as e:
+                try:
+                    filename_temp.unlink()
+                except FileNotFoundError:
+                    pass
                 return (file_id, e)
         else:
             log.info("%s exists in target. Please set overwrite to True.", filename)

--- a/modape/modis/download.py
+++ b/modape/modis/download.py
@@ -231,11 +231,13 @@ class ModisQuery(object):
                     response.raise_for_status()
                     file_metadata = self._parse_hdfxml(response)
 
+                    # check filesize
+                    assert filename_temp.stat().st_size == file_metadata["FileSize"]
                     with open(filename_temp, "rb") as openfile:
                         checksum = cksum(openfile)
-
-                    assert filename_temp.stat().st_size == file_metadata["FileSize"]
+                    # check checksum
                     assert checksum == file_metadata["Checksum"]
+
                 # QUESTION: should we remove temp file?
                 shutil.move(filename_temp, filename)
 
@@ -326,10 +328,9 @@ class ModisQuery(object):
                     downloaded.append(fid)
 
             if to_download:
-                n_todo = len(to_download)
                 if retry_count < max_retries or max_retries == -1:
                     retry_count += 1
-                    log.debug("Retrying downloads! Files left: %s", n_todo)
+                    log.debug("Retrying downloads! Files left: %s", len(to_download))
                     if max_retries > 0:
                         log.debug("Try %s of %s", retry_count, max_retries)
                     continue

--- a/modape/modis/download.py
+++ b/modape/modis/download.py
@@ -296,7 +296,9 @@ class ModisQuery(object):
 
             with SessionWithHeaderRedirection(username, password) as session:
 
-                retries = Retry(total=5, backoff_factor=1, status_forcelist=[502, 503, 504])
+                backoff = min(450, 2**retry_count)
+
+                retries = Retry(total=5, backoff_factor=backoff, status_forcelist=[502, 503, 504])
                 session.mount(
                     "https://",
                     HTTPAdapter(pool_connections=nthreads, pool_maxsize=nthreads*2, max_retries=retries)

--- a/modape/modis/download.py
+++ b/modape/modis/download.py
@@ -135,7 +135,6 @@ class ModisQuery(object):
             fid = result["file_id"]
             del result["file_id"]
 
-            #self.results.append(result)
             self.results.update({fid: result})
 
         # final results

--- a/modape/modis/download.py
+++ b/modape/modis/download.py
@@ -215,7 +215,7 @@ class ModisQuery(object):
 
         if not exists(filename_full) or overwrite:
 
-            filename_temp = filename.with_suffix(".modapedl")
+            filename_temp = filename_full.with_suffix(".modapedl")
 
             try:
 

--- a/modape/scripts/modis_download.py
+++ b/modape/scripts/modis_download.py
@@ -165,6 +165,8 @@ def cli(products: List[str],
             click.echo(values)
             click.echo("\n")
 
+    downloaded = []
+
     if download:
 
         click.echo('Downloading!')

--- a/modape/scripts/modis_download.py
+++ b/modape/scripts/modis_download.py
@@ -80,7 +80,7 @@ def cli(products: List[str],
         collection (str): MODIS collection version.
 
     Returns:
-        List of downloaded HDF filenames (if overwrite is False, also already existing filenames are included)
+        List of downloaded HDF filenames (if overwrite is False, also skipped downloads are included if already existing in targetdir)
     """
 
     click.echo("\nSTART download_modis.py!")

--- a/modape/scripts/modis_download.py
+++ b/modape/scripts/modis_download.py
@@ -27,6 +27,8 @@ from modape.modis import ModisQuery
 @click.option("--print-results", is_flag=True, help="Print results to console")
 @click.option("--download", is_flag=True, help="Download data")
 @click.option("--overwrite", is_flag=True, help="Overwrite existing files")
+@click.option("--robust", is_flag=True, help="Perform robust download")
+@click.option("--max-retries", type=click.INT, help="Max number of retries for downloading", default=-1)
 @click.option("--multithread", is_flag=True, help="Use multiple threads for downloading")
 @click.option("--nthreads", type=click.INT, help="Number of threads to use", default=4)
 @click.option("-c", "--collection", type=click.STRING, default="006", help="MODIS collection")
@@ -43,6 +45,8 @@ def cli(products: List[str],
         print_results: bool,
         download: bool,
         overwrite: bool,
+        robust: bool,
+        max_retries: int,
         multithread: bool,
         nthreads: int,
         collection: str,
@@ -69,6 +73,8 @@ def cli(products: List[str],
         strict_dates (bool): Strict date handling.
         download (bool): Download data.
         overwrite (bool): Replace existing.
+        robust (bool): Perform robust downloading (checks file size and checksum).
+        max_retries (int): Maximum number of retries for failed downloads (default is -1, infinite).
         multithread (bool): Use multiple threads for downloading.
         nthreads (int): Number of threads for multithread.
         collection (str): MODIS collection version.
@@ -154,9 +160,10 @@ def cli(products: List[str],
 
     if print_results:
         click.echo("\n")
-        for res in query.results:
-            click.echo(res)
-        click.echo("\n")
+        for key, values in query.results.items():
+            click.secho(key, bold=True)
+            click.echo(values)
+            click.echo("\n")
 
     if download:
 
@@ -164,17 +171,19 @@ def cli(products: List[str],
 
         if query.nresults > 0:
 
-            query.download(
+            downloaded = query.download(
                 targetdir=targetdir,
                 username=username,
                 password=password,
                 overwrite=overwrite,
                 multithread=multithread,
                 nthreads=nthreads,
+                robust=robust,
+                max_retries=max_retries,
             )
 
     click.echo('modis_download.py COMPLETED! Bye! \n')
-    return query.results
+    return downloaded
 
 def cli_wrap():
     """Wrapper for cli"""

--- a/modape/scripts/modis_download.py
+++ b/modape/scripts/modis_download.py
@@ -80,7 +80,7 @@ def cli(products: List[str],
         collection (str): MODIS collection version.
 
     Returns:
-        List of results returned by CMR API for query
+        List of downloaded HDF filenames (if overwrite is False, also already existing filenames are included)
     """
 
     click.echo("\nSTART download_modis.py!")

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         "python-cmr>=0.4",
         "requests>=2",
         "pandas>=0.24",
+        "pycksum>=0.4.3",
     ],
     python_requires=">=3, <4",
 )


### PR DESCRIPTION
This PR implements 

- A robust download option, checking for correct file size and checksum value
- Re-try of failed downloads, until a maximum number specified by user (or indefinitely by default)

both for #138 

#### Other Notable changes

- Files are not directly downloaded to the final filename, to avoid having corrupt files that look like they were successfully downloaded. The files being downloaded get a `.modapedl` suffix.
- The results from the query are now represented as `dict`, with the key being the file ID and the value being another `dict` with the relevant info
- `ModisQuery.download` now returns only a list with downloaded file IDs, which is in turn returned by `modis_download.cli`
- The robust download and the number of retries can be set by the user through `modis_download`

#### Open questions

- Do we need a user defined wait period for retry? Or do we just wait a defined time, or none as implemented currently?
- Do we want to remove any `.modapedl` files that failed to download fully?
- Currently, encountering an error during downloading will trigger re-trying and eventually lead to a `DownloadError` exception. This will lead to no download results list being returned. Should we change that approach?
