### PR TITLE
modis_collect: added consistency check

### DIFF
--- a/modape/modis/collect.py
+++ b/modape/modis/collect.py
@@ -209,6 +209,13 @@ class ModisRawH5(HDF5Base):
 
         super().__init__(filename=filename)
 
+    @staticmethod
+    def existing(targetdir, vam_product_code, re_product, re_version):
+        patt = re.compile(f"^{re_product}\\.h[0-9]{{2}}v[0-9]{{2}}\\.{re_version}\\.{vam_product_code}\\.h5")
+        for h5 in Path(f"{targetdir}/{vam_product_code}").glob('*.h5'):
+            if patt.match(h5.name):
+                yield h5
+
     def create(self,
                compression: str = "gzip",
                chunks: Tuple[int] = None) -> None:


### PR DESCRIPTION
Tiles and dates (DOYs) that are about to be collected are identified and forced to be to be consistent: .hdf file for each tile, each DOY. This adds a new flag to modis_collect: `--date-tile-consistency`

I have tested the following:
1. With an existing raw H5 archive: fed modis_window with some totally different tiles => collect nicely refuses
2. Downloaded 3 time steps for 3 tiles, then removed 1 .hdf file => nicely detected and refused
3. Successful, consistent download of some timesteps for selected tiles => nicely accepted by modis_collect