### PR TITLE
check for tile/date consistency (cf. #159)

### DIFF
--- a/modape/scripts/modis_collect.py
+++ b/modape/scripts/modis_collect.py
@@ -133,12 +133,12 @@ def cli(src_dir: str,
                     raise ValueError("Required tile %s not found in input files for product %s" % (reqtile, product))
                 log.debug("Tile %s OK!", reqtile)
 
-                timestamps.append([x.split(".")[0] for x in datetiles if reqtile in x])
+                timestamps.append({x.split(".")[0] for x in datetiles if reqtile in x})
 
             iterator = iter(timestamps)
-            reference_len = len(next(iterator))
-            if not all(len(x) == reference_len for x in iterator):
-                raise ValueError("Not all tiles have same number of timesteps for product %s!" % product)
+            reference = next(iterator)
+            if not all(x == reference for x in iterator):
+                raise ValueError("Not all tiles have same timesteps for product %s!" % product)
             log.debug("Timestamps OK for %s", product)
 
     groups = [".*".join(x) for x in zip(products, tiles, versions)]

--- a/modape/scripts/modis_collect.py
+++ b/modape/scripts/modis_collect.py
@@ -86,7 +86,7 @@ def cli(src_dir: str,
             assert re.match(tile_regxp, tile_sel.lower())
             _tiles.append(tile_sel.lower())
 
-        tiles_required = _tiles
+        tiles_required = frozenset(_tiles)
 
     click.echo("Starting MODIS COLLECT!")
 
@@ -128,11 +128,9 @@ def cli(src_dir: str,
             product_tiles = {x.split(".")[1] for x in datetiles}
 
             timestamps = []
+            if product_tiles != tiles_required:
+                raise ValueError("Tiles for product %s don't match tiles-required!" % product)
             for reqtile in tiles_required:
-                if reqtile not in product_tiles:
-                    raise ValueError("Required tile %s not found in input files for product %s" % (reqtile, product))
-                log.debug("Tile %s OK!", reqtile)
-
                 timestamps.append({x.split(".")[0] for x in datetiles if reqtile in x})
 
             iterator = iter(timestamps)


### PR DESCRIPTION
If `tiles_required` is passed: 

- check if all of the tiles requested are included in the input files for each product
- check if the number of timestamps is consistent between tiles

Open Qs:

- Like this, more tiles than requested in `tiles_required` can be passed it, but all tiles in `tiles_required` need to be present. Do we want to constrict the tiles to `tiles_required`?
- Should the check for timestamps be optional on top of `tiles_required`?
- Line 127 could be changed to a set, avoiding potential issues with duplicates 

@interob please check initial draft: could this approach work for you?
