### PR TITLE
Window resolution and last collected

### DIFF
--- a/modape/modis/smooth.py
+++ b/modape/modis/smooth.py
@@ -438,7 +438,7 @@ class ModisSmoothH5(HDF5Base):
 
 
     @property
-    def last_collected_in_raw(self):
+    def last_collected(self):
         """Last collected date in raw file"""
         with h5py.File(self.rawfile, "r") as h5f_raw:
             dates = h5f_raw.get("dates")

--- a/modape/modis/smooth.py
+++ b/modape/modis/smooth.py
@@ -441,7 +441,7 @@ class ModisSmoothH5(HDF5Base):
     def last_collected_in_raw(self):
         """Last collected date in raw file"""
         with h5py.File(self.rawfile, "r") as h5f_raw:
-            dates = h5f_raw.get("rawdates")
+            dates = h5f_raw.get("dates")
             last_date = dates[-1].decode()
 
         return last_date

--- a/modape/modis/smooth.py
+++ b/modape/modis/smooth.py
@@ -446,7 +446,7 @@ class ModisSmoothH5(HDF5Base):
 
         return last_date
 
-
+    @property
     def last_smoothed(self):
         """Last smoothed date in file"""
         assert self.exists, "File doesn't exist!"

--- a/modape/modis/smooth.py
+++ b/modape/modis/smooth.py
@@ -438,8 +438,17 @@ class ModisSmoothH5(HDF5Base):
 
 
     @property
-    def last_collected(self):
-        """Last collected date in file"""
+    def last_collected_in_raw(self):
+        """Last collected date in raw file"""
+        with h5py.File(self.rawfile, "r") as h5f_raw:
+            dates = h5f_raw.get("rawdates")
+            last_date = dates[-1].decode()
+
+        return last_date
+
+
+    def last_smoothed(self):
+        """Last smoothed date in file"""
         assert self.exists, "File doesn't exist!"
 
         with h5py.File(self.filename, "r") as h5_open:

--- a/modape/modis/window.py
+++ b/modape/modis/window.py
@@ -141,7 +141,7 @@ class ModisMosaic(object):
             force_doy = True
 
         if "xRes" in kwargs and "yRes" in kwargs:
-            output_res = [kwargs["xRes"], kwargs["yRes"]]
+            output_res = [float(kwargs["xRes"]), float(kwargs["yRes"])]
             del kwargs["xRes"]
             del kwargs["yRes"]
 

--- a/modape/modis/window.py
+++ b/modape/modis/window.py
@@ -79,6 +79,7 @@ class ModisMosaic(object):
                          stop: datetime.date = None,
                          clip_valid: bool = False,
                          round_int: int = None,
+                         last_smoothed: str = None,
                          **kwargs,
                         ) -> List:
         """Generate GeoTIFF mosaics/subsets.
@@ -116,6 +117,7 @@ class ModisMosaic(object):
             stop (datetime.date): Stop date for mosaics.
             clip_valid (bool): Clip values to valid range for MODIS product.
             round_int (int): Round the output.
+            last_smoothed (str): Rawdate (MODIS time step) that is checked to be the last in series at time of smoothing.
             **kwargs (type): **kwags passed on to `gdal.WarpOptions` and `gdal.TranslateOptions`.
 
         Raises:
@@ -223,6 +225,7 @@ class ModisMosaic(object):
                         clip_valid,
                         round_int=round_int,
                         ix=ii,
+                        last_smoothed=last_smoothed
                     )
                 )
 
@@ -274,12 +277,20 @@ class ModisMosaic(object):
                     dataset: str,
                     clip_valid: bool,
                     round_int: int,
-                    ix: int = None) -> str:
+                    ix: int = None,
+                    last_smoothed: str = None) -> str:
 
         if dataset not in ["data", "sgrid"]:
             raise NotImplementedError("_get_raster only implemented for datasetds 'data' and 'sgrid'")
 
         with h5py.File(file, "r") as h5f_open:
+
+            if last_smoothed is not None:
+                dates = h5f_open.get("rawdates")
+                last_date = dates[-1].decode()
+                assert last_smoothed == last_date, \
+                    f"Last smoothed date in {file} is {last_date} not {last_smoothed}"
+                
             ds = h5f_open.get(dataset)
             assert ds, "Dataset doesn't exist!"
             dataset_shape = ds.shape

--- a/modape/scripts/modis_smooth.py
+++ b/modape/scripts/modis_smooth.py
@@ -217,7 +217,7 @@ def _worker(rawfile: str,
         smt_h5.create()
 
     if last_collected is not None:
-        last_collected_in_rawfile = smt_h5.last_collected_in_raw
+        last_collected_in_rawfile = smt_h5.last_collected
 
         if not last_collected_in_rawfile:
             raise ValueError(f"No last_collected recorded in {smt_h5.rawfile}")

--- a/modape/scripts/modis_smooth.py
+++ b/modape/scripts/modis_smooth.py
@@ -217,13 +217,13 @@ def _worker(rawfile: str,
         smt_h5.create()
 
     if last_collected is not None:
-        last_collected_infile = smt_h5.last_collected
+        last_collected_in_rawfile = smt_h5.last_collected_in_raw
 
-        if not last_collected_infile:
-            raise ValueError(f"No last_collected recorded in {smt_h5.filename}")
+        if not last_collected_in_rawfile:
+            raise ValueError(f"No last_collected recorded in {smt_h5.rawfile}")
 
-        assert last_collected == last_collected_infile, \
-         f"Last collected date in file is {last_collected_infile} not {last_collected}"
+        assert last_collected == last_collected_in_rawfile, \
+         f"Last collected date in {smt_h5.rawfile} is {last_collected_in_rawfile} not {last_collected}"
 
     smt_h5.smooth(**kwargs)
 

--- a/modape/scripts/modis_window.py
+++ b/modape/scripts/modis_window.py
@@ -33,6 +33,7 @@ log = logging.getLogger(__name__)
 @click.option("--round-int", type=click.INT, help="Round to integer places (either decimals or exponent of 10)")
 @click.option("--gdal-kwarg", type=click.STRING, multiple=True, help="Addition kwargs for GDAL")
 @click.option("--overwrite", is_flag=True, help="Overwrite existsing Tiffs")
+@click.option('--last-smoothed', type=click.DateTime(formats=['%Y%j']), help='Last smoothed date in julian format (YYYYDDD - %Y%j)')
 def cli(src: str,
         targetdir: str,
         begin_date: datetime.date,
@@ -48,7 +49,8 @@ def cli(src: str,
         clip_valid: bool,
         round_int: int,
         gdal_kwarg: Union[Tuple[str], Dict[str, Union[str, int, float]]],
-        overwrite: bool) -> List:
+        overwrite: bool,
+        last_smoothed: str) -> List:
     """Creates GeoTiff Mosaics from HDF5 files.
 
     The input can be either raw or smoothed HDF5 files. With the latter,
@@ -88,6 +90,7 @@ def cli(src: str,
                                  the Tuple of strings (item formatting: "key=value") is parsed into a dict.
                                  Alternatively, passing a dict instead of a Tuple[str] is also supported.
         overwrite (bool): Overwrite existing Tiffs.
+        last_smoothed (str): Rawdate (MODIS time step) that is checked to be the last in series at time of smoothing.
 
     """
 
@@ -174,7 +177,10 @@ def cli(src: str,
             )
         else:
             gdal_kwargs = gdal_kwarg
-
+    
+    if last_smoothed is not None:
+        last_smoothed = last_smoothed.strftime("%Y%j")
+    
     click.echo("\nSTARTING modis_window.py!")
 
     mosaics = []
@@ -199,6 +205,7 @@ def cli(src: str,
                 stop=end_date,
                 clip_valid=clip_valid,
                 round_int=round_int,
+                last_smoothed=last_smoothed,
                 creationOptions=list(co),
                 **gdal_kwargs,
                 )

--- a/tests/test_modis.py
+++ b/tests/test_modis.py
@@ -657,8 +657,8 @@ class TestModisSmooth(unittest.TestCase):
             dates = hdf5_file.get("dates")
             self.assertTrue(dates)
 
-        self.assertNotEqual(smtH5.last_collected, "2002201")
-        self.assertEqual(smtH5.last_collected, "2002209")
+        self.assertNotEqual(smtH5.last_smoothed, "2002201")
+        self.assertEqual(smtH5.last_smoothed, "2002209")
 
         smtH5.filename.unlink()
 


### PR DESCRIPTION
Addresses #164, #165, #166.

For modis_window the missing last_collected option has been added under a different, yet more intuitive name: `--last-smoothed` -- because that's exactly that is being checked.

Similarly, but then right the opposite: for modis_smooth the `--last-collected` option now indeed checks the last raw data as collected in the raw .h5 file (previously, it was checking the `rawdates` attribute in the smoothed .h5 file)